### PR TITLE
Only "update resource" if required.

### DIFF
--- a/providers/key.rb
+++ b/providers/key.rb
@@ -30,10 +30,10 @@ end
 action :allow do
   execute "Make remote host known" do
     command %{
-      host_exists="$(ssh-keygen -F #{new_resource.host} -f #{new_resource.local_known_hosts} | grep -c found)"
-      test $host_exists = 0 && ssh-keyscan -p #{new_resource.port} #{new_resource.host} >> #{new_resource.local_known_hosts}
+      ssh-keyscan -p #{new_resource.port} #{new_resource.host} >> #{new_resource.local_known_hosts}
       exit 0
     }
+    not_if %{ ssh-keygen -F #{new_resource.host} -f #{new_resource.local_known_hosts} | grep -c found }
   end
 end
 


### PR DESCRIPTION
This cleans up the "x resources updated" message at the end of a Chef
run. It also stops ssh from restarting unless needed.
