### PR TITLE
Update metadata -  added name

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "ssh"
 maintainer       "Gerhard Lazu"
 maintainer_email "gerhard@lazu.co.uk"
 license          "Apache 2.0"


### PR DESCRIPTION
Fixing the problem that comes up when using Berkshelf:

```
The metadata at 'xxx' does not contain a 'name' attribute. While Chef does not strictly enforce 
this requirement, Ridley cannot continue without a valid metadata 'name' entry. 
(Ridley::Errors::MissingNameAttribute)
```
